### PR TITLE
他のユーザー情報を認証から紐づけて表示

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
+  provider  = "postgresql"
   url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
@@ -11,81 +11,82 @@ datasource db {
 model Message {
   id        String   @id @default(uuid())
   text      String
-  userId    String
+  userId    String   @db.Uuid
   roomId    String?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt @default(now())
-
+  updatedAt DateTime @default(now()) @updatedAt
   room      Room?    @relation(fields: [roomId], references: [id])
+  profile   Profile  @relation(fields: [userId], references: [userId])
 }
 
 model Room {
-  id        String   @id @default(uuid())
-  maxUser Int
-  area String
-  mealType String
-  date String
-  isClosed Boolean
-  createdAt DateTime @default(now())
-
-  RoomParticipant RoomParticipant[]
-  Message Message[]
-
+  id                    String                  @id @default(uuid())
+  maxUser               Int
+  area                  String
+  mealType              String
+  date                  String
+  isClosed              Boolean
+  createdAt             DateTime                @default(now())
+  Message               Message[]
   RecommendedRestaurant RecommendedRestaurant[] @relation("RecommendedRestaurantRoom")
+  RoomParticipant       RoomParticipant[]
 }
 
-model RoomParticipant{
-  id String @id @default(uuid())
+model RoomParticipant {
+  id     String  @id @default(uuid())
   roomId String
-  userId String
+  userId String  @db.Uuid
   isHost Boolean
-
-  room Room    @relation(fields: [roomId], references: [id])
+  room   Room    @relation(fields: [roomId], references: [id])
+  profile Profile @relation(fields: [userId], references: [userId]) 
 }
 
-model Restaurant{
-  id String @id @default(uuid())
-
-  name String
-  url String
-  genre String
-  area String
-  station String
-  distance String
-  description String
-  
-  rating Float
-  reviewCount Int
-  savedCount Int
-  
-  budgetDinner String
-  budgetLunch String
-  
-  isHotRestaurant Boolean @default(false)
-  
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
+model Restaurant {
+  id                    String                  @id @default(uuid())
+  name                  String
+  url                   String
+  genre                 String
+  area                  String
+  station               String
+  distance              String
+  description           String
+  rating                Float
+  reviewCount           Int
+  savedCount            Int
+  budgetDinner          String
+  budgetLunch           String
+  isHotRestaurant       Boolean                 @default(false)
+  createdAt             DateTime                @default(now())
+  updatedAt             DateTime                @updatedAt
   RecommendedRestaurant RecommendedRestaurant[]
-
 }
 
 model RecommendedRestaurant {
-  id String @id @default(uuid())
-
+  id              String     @id @default(uuid())
   recommendReason String
-  matchScore Int
-  
-  userId String
-  roomId String?
-  restaurantId String
-
-  isSelected Boolean @default(false)
-  
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  room Room? @relation("RecommendedRestaurantRoom", fields: [roomId], references: [id])
-  restaurant Restaurant @relation(fields: [restaurantId], references: [id])
+  matchScore      Int
+  userId          String     @db.Uuid
+  roomId          String?
+  restaurantId    String
+  isSelected      Boolean    @default(false)
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+  restaurant      Restaurant @relation(fields: [restaurantId], references: [id])
+  room            Room?      @relation("RecommendedRestaurantRoom", fields: [roomId], references: [id])
+  profile         Profile    @relation(fields: [userId], references: [userId])
 }
 
+model Profile {
+  id                    String                  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId                String                  @unique @db.Uuid
+  name                  String?
+  avatarUrl             String?
+  created_at            DateTime                @default(now())
+  updated_at            DateTime                @updatedAt
+  
+  Message               Message[]
+  RecommendedRestaurant RecommendedRestaurant[]
+  RoomParticipant       RoomParticipant[]  
+
+  @@map("profiles")
+}

--- a/src/app/api/rooms/[roomid]/route.ts
+++ b/src/app/api/rooms/[roomid]/route.ts
@@ -21,9 +21,36 @@ async function getRoomInfo(roomId: string) {
     return { success: false, error: "認証が必要です" };
   }
 
+  let userProfile = await prisma.profile.findUnique({
+    where: { userId: user.id },
+  });
+
+  if (!userProfile) {
+    userProfile = await prisma.profile.create({
+      data: {
+        userId: user.id,
+        name:
+          user.user_metadata?.name || user.email?.split("@")[0] || "ユーザー",
+        avatarUrl: user.user_metadata?.avatar_url || null,
+      },
+    });
+  }
+
   const roomWithParticipant = await prisma.room.findUnique({
     where: { id: roomId },
-    include: { RoomParticipant: true },
+    include: {
+      RoomParticipant: {
+        include: {
+          profile: {
+            select: {
+              name: true,
+              avatarUrl: true,
+              userId: true,
+            },
+          },
+        },
+      },
+    },
   });
 
   if (!roomWithParticipant) {
@@ -48,9 +75,36 @@ async function joinRoom(roomId: string) {
     return { success: false, error: "認証が必要です" };
   }
 
+  let userProfile = await prisma.profile.findUnique({
+    where: { userId: user.id },
+  });
+
+  if (!userProfile) {
+    userProfile = await prisma.profile.create({
+      data: {
+        userId: user.id,
+        name:
+          user.user_metadata?.name || user.email?.split("@")[0] || "ユーザー",
+        avatarUrl: user.user_metadata?.avatar_url || null,
+      },
+    });
+  }
+
   const roomWithParticipant = await prisma.room.findUnique({
     where: { id: roomId },
-    include: { RoomParticipant: true },
+    include: {
+      RoomParticipant: {
+        include: {
+          profile: {
+            select: {
+              name: true,
+              avatarUrl: true,
+              userId: true,
+            },
+          },
+        },
+      },
+    },
   });
 
   if (!roomWithParticipant) {
@@ -80,8 +134,21 @@ async function joinRoom(roomId: string) {
 
   const updatedRoom = await prisma.room.findUnique({
     where: { id: roomId },
-    include: { RoomParticipant: true },
+    include: {
+      RoomParticipant: {
+        include: {
+          profile: {
+            select: {
+              name: true,
+              avatarUrl: true,
+              userId: true,
+            },
+          },
+        },
+      },
+    },
   });
+
   if (!updatedRoom) {
     return { success: false, error: "ルーム情報の取得に失敗しました" };
   }

--- a/src/components/RoomParticipants/RoomParticipants.tsx
+++ b/src/components/RoomParticipants/RoomParticipants.tsx
@@ -72,6 +72,7 @@ export function ParticipantsSection({
               <Box className={styles.avatarWrapper}>
                 <Avatar
                   src={participant.profile.avatarUrl}
+                  alt={displayName}
                   radius="xl"
                   size="md"
                   color={participant.isHost ? "blue" : "gray"}

--- a/src/components/RoomParticipants/RoomParticipants.tsx
+++ b/src/components/RoomParticipants/RoomParticipants.tsx
@@ -17,6 +17,11 @@ export interface RoomParticipant {
   roomId: string;
   userId: string;
   isHost: boolean;
+  profile: {
+    name: string | null;
+    avatarUrl: string | null;
+    userId: string;
+  };
 }
 
 interface ParticipantsSectionProps {
@@ -53,33 +58,44 @@ export function ParticipantsSection({
       />
 
       <Group>
-        {participants.map((participant, index) => (
-          <Tooltip
-            key={participant.id}
-            label={participant.isHost ? "ホスト" : `参加者${index + 1}`}
-            withArrow
-          >
-            <Box className={styles.avatarWrapper}>
-              <Avatar
-                radius="xl"
-                size="md"
-                color={participant.isHost ? "blue" : "gray"}
-              >
-                {participant.isHost ? "H" : `P${index + 1}`}
-              </Avatar>
-              {participant.isHost && (
-                <ThemeIcon
-                  size="xs"
+        {participants.map((participant, index) => {
+          const displayName =
+            participant.profile.name || `ユーザー${index + 1}`;
+          const roleLabel = participant.isHost ? "ホスト" : "参加者";
+
+          return (
+            <Tooltip
+              key={participant.id}
+              label={`${displayName} (${roleLabel})`}
+              withArrow
+            >
+              <Box className={styles.avatarWrapper}>
+                <Avatar
+                  src={participant.profile.avatarUrl}
                   radius="xl"
-                  color="yellow"
-                  className={styles.hostBadge}
+                  size="md"
+                  color={participant.isHost ? "blue" : "gray"}
                 >
-                  <IconCrown size={12} />
-                </ThemeIcon>
-              )}
-            </Box>
-          </Tooltip>
-        ))}
+                  {participant.profile.avatarUrl
+                    ? null
+                    : participant.isHost
+                      ? "H"
+                      : displayName.charAt(0)}
+                </Avatar>
+                {participant.isHost && (
+                  <ThemeIcon
+                    size="xs"
+                    radius="xl"
+                    color="yellow"
+                    className={styles.hostBadge}
+                  >
+                    <IconCrown size={12} />
+                  </ThemeIcon>
+                )}
+              </Box>
+            </Tooltip>
+          );
+        })}
 
         {participantCount < maxUser && (
           <Text size="sm" c="dimmed">


### PR DESCRIPTION
## 概要
データベーススキーマの更新:

name、avatarUrl、userIdなどのユーザー固有のデータを管理する新しいProfileモデルを追加。このモデルは現在Message、RoomParticipant、RecommendedRestaurantモデルで参照されています
一貫性のため、複数のモデル（Message、RoomParticipant、RecommendedRestaurant）のuserIdフィールドを@db.Uuid型を使用するように更新

APIの機能強化:

認証されたユーザーのProfileが作成または取得されることを保証するようにgetRoomInfoとjoinRoom関数を修正
RoomParticipantの詳細を取得する際にProfileデータを含めるように機能を更新

UIの改善:

Profileモデルから参加者の名前とアバターを表示するようにParticipantsSectionコンポーネントを更新
プロフィールデータが不足している場合のフォールバックロジックを追加
参加者の名前と役割の両方を表示するようにツールチップを改善